### PR TITLE
fix(test/schemas) - Optional test_data_href

### DIFF
--- a/test/schemas/function.js
+++ b/test/schemas/function.js
@@ -70,7 +70,7 @@ module.exports = {
                 test_data_href: {
                     type: 'string',
                     pattern: scmUrlPattern,
-                    required: true
+                    required: false
                 },
                 secrets_file_href: {
                     type: 'string',


### PR DESCRIPTION
`test_data_href` is all the sudden not showing up in the response body. So make it optional.
